### PR TITLE
Add SetActionTextPos, mark internal functions as static

### DIFF
--- a/action-text.inc
+++ b/action-text.inc
@@ -120,3 +120,13 @@ stock bool:IsPlayerViewingActionText(playerid) {
 
 	return viewingActionText[playerid];
 }
+
+stock SetActionTextPos(playerid, Float:x, Float:y) {
+	if(!IsPlayerConnected(playerid)) {
+		return 1;
+	}
+
+	PlayerTextDrawSetPos(playerid, actionTextUI[playerid], x, y);
+
+	return 0;
+}

--- a/action-text.inc
+++ b/action-text.inc
@@ -56,7 +56,7 @@ hook OnFilterScriptExit() {
 }
 #endif
 
-_actionText_CreateUI(playerid) {
+static _actionText_CreateUI(playerid) {
 	actionTextUI[playerid] = CreatePlayerTextDraw(playerid, 320.000000, 320.000000, "_");
 	PlayerTextDrawAlignment(playerid, actionTextUI[playerid], TEXT_DRAW_ALIGN_CENTRE);
 	PlayerTextDrawBackgroundColour(playerid, actionTextUI[playerid], 255);
@@ -66,7 +66,7 @@ _actionText_CreateUI(playerid) {
 	PlayerTextDrawSetOutline(playerid, actionTextUI[playerid], 1);
 }
 
-_actionText_DeleteUI(playerid, doTD = false) {
+static _actionText_DeleteUI(playerid, bool:doTD = false) {
 	if(doTD) {
 		PlayerTextDrawHide(playerid, actionTextUI[playerid]);
 		PlayerTextDrawDestroy(playerid, actionTextUI[playerid]);


### PR DESCRIPTION
- Add `SetActionTextPos` so people can adjust the position of the action text. On my server I have to lower the position once the inventory is open.
- Internal functions prefixed with `_` should be `static` functions so they don't get exposed.
- `doTD` is a boolean, it should be tagged as such.